### PR TITLE
Implementation of graceful server shutdown, fixes #9

### DIFF
--- a/cmd/kv-tcp/main.go
+++ b/cmd/kv-tcp/main.go
@@ -85,11 +85,10 @@ func main() {
 
 	s := server{ln.(*net.TCPListener), store, transactor, make(chan bool)}
 
-	var gracefulStop = make(chan os.Signal)
-	signal.Notify(gracefulStop, syscall.SIGTERM)
-	signal.Notify(gracefulStop, syscall.SIGINT)
+	gracefulStopSignal := make(chan os.Signal, 1)
+	signal.Notify(gracefulStopSignal, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
-		<-gracefulStop
+		<-gracefulStopSignal
 		logrus.Infoln("Begin graceful server shutdown")
 		ln.Close() // unblocks Accept and refuse new attempts to connect
 		s.stop()

--- a/cmd/kv-tcp/main.go
+++ b/cmd/kv-tcp/main.go
@@ -88,8 +88,8 @@ func main() {
 	gracefulStopSignal := make(chan os.Signal, 1)
 	signal.Notify(gracefulStopSignal, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
-		<-gracefulStopSignal
-		logrus.Infoln("Begin graceful server shutdown")
+		sig := <-gracefulStopSignal
+		logrus.Infof("Signal %v received. Begin graceful server shutdown", sig)
 		ln.Close() // unblocks Accept and refuse new attempts to connect
 		s.stop()
 		os.Exit(0)


### PR DESCRIPTION
fixes #9 
Uses a signal channel to get OS kill notifications and extends the `server` struct with a `stop` method that closes the listener and waits for all existing connections to finish before letting the stop goroutine exit the program with code 0